### PR TITLE
ページネーションの実装

### DIFF
--- a/src/components/pagination/Pagination.jsx
+++ b/src/components/pagination/Pagination.jsx
@@ -3,37 +3,122 @@ import Link from "next/link";
 import { BLOG_LIMIT } from "@/constants/blogLimit";
 import styles from "./Pagination.module.scss";
 
-export const Pagination = ({ totalCount }) => {
-  //1ページに何枚表示するか
-  const PER_PAGE = BLOG_LIMIT;
-
+export const Pagination = ({ totalCount, limit }) => {
+  //全部で何ページのページネーションにするかの計算
+  const totalPages = Math.ceil(totalCount / limit);
   // 現在のページ番号を取得
   const router = useRouter();
-  const currentPage = parseInt(router.query.pageNum || "1", 10);
+  /**
+   * ||の代わりに??を使うことで、undefinedまたはnullの場合のみデフォルト値を適用できます。
+   * ??は、0や空文字列（""）を「有効な値」として扱うため、意図しないデフォルト値の適用を防ぎます。
+   */
+  const currentPage = Number(router.query.pageNum ?? 1);
 
-  const range = (start, end) =>
-    /**
-     * スプレッド構文で展開し、未定義の要素を埋める。
-     */
-    [...Array(end - start + 1)].map((_, i) => start + i);
+  const getPageNumbers = () => {
+    const pageNumbers = [];
+    //現在のページを中心に表示する範囲
+    const range = 2;
+
+    for (let i = 1; i <= totalPages; i++) {
+      if (
+        //最初のページ
+        i === 1 ||
+        // 最後のページ
+        i === totalPages ||
+        // 現在のページの前後範囲 
+        (i >= currentPage - range && i <= currentPage + range)
+      ) {
+        //ページ番号 i を配列に追加します。
+        pageNumbers.push(i);
+        // 配列の最後の要素が null ではないことを確認します。これにより、連続して null を追加するのを防ぎます。
+      } else if (pageNumbers[pageNumbers.length - 1] !== null) {
+        // 表示しない部分に null を挿入します。
+        pageNumbers.push(null);
+      }
+    }
+    return pageNumbers;
+  };
+
   return (
-    <ul className={styles.pageList}>
-      <li>
-        <Link href={currentPage > 1 ? `/page/${currentPage - 1}` : "#"} className={currentPage === 1 ? styles.disabled : ""}>
-          前へ
-        </Link>
-      </li>
-      {range(1, Math.ceil(totalCount / PER_PAGE)).map((number) => (
-        <li
-          className={currentPage === number ? styles.currentStyle : ""}
-          key={number}
-        >
-          <Link href={`/page/${number}`}>{number}</Link>
+    <nav>
+      <ul className={styles.pagination}>
+        <li>
+          <Link
+            disabled={currentPage === 1}
+            href={currentPage > 1 ? `/page/${currentPage - 1}` : "#"}
+            className={`${styles.paginationButton} ${
+              currentPage === 1 ? styles.disabled : ""
+            }`}
+          >
+            前へ
+          </Link>
         </li>
-      ))}
-      <li>
-        <Link href={currentPage >= 1 ? `/page/${currentPage + 1}` : "#"} className={currentPage === (totalCount / PER_PAGE) ? styles.disabled : ""}>次へ</Link>
-      </li>
-    </ul>
+
+        {getPageNumbers().map((page, index) =>
+          page === null ? (
+            <span key={index} className={styles.paginationEllipsis}>
+              ...
+            </span>
+          ) : (
+            <li key={index}>
+              <Link
+                href={`/page/${page}`}
+                className={`${styles.paginationPage} ${
+                  page === currentPage ? styles.active : ""
+                }`}
+              >
+                {page}
+              </Link>
+            </li>
+          )
+        )}
+
+        <li>
+          <Link
+            disabled={currentPage === totalPages}
+            href={currentPage >= 1 ? `/page/${currentPage + 1}` : "#"}
+            className={`${styles.paginationButton} ${
+              currentPage === totalPages ? styles.disabled : ""
+            }`}
+          >
+            次へ
+          </Link>
+        </li>
+      </ul>
+    </nav>
   );
 };
+// export const Pagination = ({ totalCount }) => {
+//   //1ページに何枚表示するか
+//   const PER_PAGE = BLOG_LIMIT;
+
+//   // 現在のページ番号を取得
+//   const router = useRouter();
+//   const currentPage = parseInt(router.query.pageNum || "1", 10);
+
+//   const range = (start, end) =>
+//     /**
+//      * スプレッド構文で展開し、未定義の要素を埋める。
+//      */
+//     [...Array(end - start + 1)].map((_, i) => start + i);
+//   return (
+//     <ul className={styles.pageList}>
+//       <li>
+//         <Link href={currentPage > 1 ? `/page/${currentPage - 1}` : "#"} className={currentPage === 1 ? styles.disabled : ""}>
+//           前へ
+//         </Link>
+//       </li>
+//       {range(1, Math.ceil(totalCount / PER_PAGE)).map((number) => (
+//         <li
+//           className={currentPage === number ? styles.currentStyle : ""}
+//           key={number}
+//         >
+//           <Link href={`/page/${number}`}>{number}</Link>
+//         </li>
+//       ))}
+//       <li>
+//         <Link href={currentPage >= 1 ? `/page/${currentPage + 1}` : "#"} className={currentPage === (totalCount / PER_PAGE) ? styles.disabled : ""}>次へ</Link>
+//       </li>
+//     </ul>
+//   );
+// };

--- a/src/components/pagination/Pagination.jsx
+++ b/src/components/pagination/Pagination.jsx
@@ -1,0 +1,39 @@
+import { useRouter } from "next/router";
+import Link from "next/link";
+import { BLOG_LIMIT } from "@/constants/blogLimit";
+import styles from "./Pagination.module.scss";
+
+export const Pagination = ({ totalCount }) => {
+  //1ページに何枚表示するか
+  const PER_PAGE = BLOG_LIMIT;
+
+  // 現在のページ番号を取得
+  const router = useRouter();
+  const currentPage = parseInt(router.query.pageNum || "1", 10);
+
+  const range = (start, end) =>
+    /**
+     * スプレッド構文で展開し、未定義の要素を埋める。
+     */
+    [...Array(end - start + 1)].map((_, i) => start + i);
+  return (
+    <ul className={styles.pageList}>
+      <li>
+        <Link href={currentPage > 1 ? `/page/${currentPage - 1}` : "#"} className={currentPage === 1 ? styles.disabled : ""}>
+          前へ
+        </Link>
+      </li>
+      {range(1, Math.ceil(totalCount / PER_PAGE)).map((number) => (
+        <li
+          className={currentPage === number ? styles.currentStyle : ""}
+          key={number}
+        >
+          <Link href={`/page/${number}`}>{number}</Link>
+        </li>
+      ))}
+      <li>
+        <Link href={currentPage >= 1 ? `/page/${currentPage + 1}` : "#"} className={currentPage === (totalCount / PER_PAGE) ? styles.disabled : ""}>次へ</Link>
+      </li>
+    </ul>
+  );
+};

--- a/src/components/pagination/Pagination.module.scss
+++ b/src/components/pagination/Pagination.module.scss
@@ -1,0 +1,21 @@
+.pageList {
+  display: flex;
+  justify-content: center;
+  list-style: none;
+  gap: 20px;
+}
+
+.currentStyle {
+  background-color: #16abff;
+  color: white;
+}
+
+.pageList a {
+  font-size: 20px;
+  padding: 5px;
+}
+
+.disabled {
+  pointer-events: none;
+  color: gray;
+}

--- a/src/components/pagination/Pagination.module.scss
+++ b/src/components/pagination/Pagination.module.scss
@@ -19,3 +19,35 @@
   pointer-events: none;
   color: gray;
 }
+
+.pagination {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  align-items: center;
+  list-style: none;
+}
+
+.paginationButton {
+  padding: 0.5rem 1rem;
+  border: 1px solid #ddd;
+  background-color: #fff;
+  cursor: pointer;
+}
+
+.paginationPage {
+  padding: 0.5rem 1rem;
+  border: 1px solid #ddd;
+  background-color: #fff;
+  cursor: pointer;
+}
+
+.paginationPage.active {
+  background-color: #0070f3;
+  color: #fff;
+  font-weight: bold;
+}
+
+.paginationEllipsis {
+  padding: 0.5rem 1rem;
+}

--- a/src/components/pagination/Pagination.tsx
+++ b/src/components/pagination/Pagination.tsx
@@ -1,9 +1,16 @@
+import { NextPage } from "next";
+
 import { useRouter } from "next/router";
 import Link from "next/link";
 import { BLOG_LIMIT } from "@/constants/blogLimit";
 import styles from "./Pagination.module.scss";
 
-export const Pagination = ({ totalCount, limit }) => {
+type PaginationProps = {
+  totalCount: number;
+  limit: number;
+}
+
+export const Pagination = ({ totalCount, limit }: PaginationProps) => {
   //全部で何ページのページネーションにするかの計算
   const totalPages = Math.ceil(totalCount / limit);
   // 現在のページ番号を取得
@@ -44,7 +51,6 @@ export const Pagination = ({ totalCount, limit }) => {
       <ul className={styles.pagination}>
         <li>
           <Link
-            disabled={currentPage === 1}
             href={currentPage > 1 ? `/page/${currentPage - 1}` : "#"}
             className={`${styles.paginationButton} ${
               currentPage === 1 ? styles.disabled : ""
@@ -75,7 +81,6 @@ export const Pagination = ({ totalCount, limit }) => {
 
         <li>
           <Link
-            disabled={currentPage === totalPages}
             href={currentPage >= 1 ? `/page/${currentPage + 1}` : "#"}
             className={`${styles.paginationButton} ${
               currentPage === totalPages ? styles.disabled : ""

--- a/src/components/pagination/Pagination.tsx
+++ b/src/components/pagination/Pagination.tsx
@@ -1,123 +1,88 @@
 import { NextPage } from "next";
-
-import { useRouter } from "next/router";
+import { Fragment } from "react";
+import { range } from "@/utils/range";
 import Link from "next/link";
-import { BLOG_LIMIT } from "@/constants/blogLimit";
 import styles from "./Pagination.module.scss";
 
 type PaginationProps = {
   totalCount: number;
   limit: number;
   currentPage: number;
-}
+};
 
-export const Pagination = ({ totalCount, limit, currentPage }: PaginationProps) => {
+export const Pagination = ({
+  totalCount,
+  limit,
+  currentPage,
+}: PaginationProps) => {
   //全部で何ページのページネーションにするかの計算
   const totalPages = Math.ceil(totalCount / limit);
 
-  const getPageNumbers = () => {
-    const pageNumbers = [];
-    //現在のページを中心に表示する範囲
-    const range = 2;
+  // ページネーションの長さ　一旦propsではなくココに記述
+  const maxNumLength = 7;
+  // 表示数の半分
+  const halfMaxNumLength = Math.floor(maxNumLength / 2);
 
-    for (let i = 1; i <= totalPages; i++) {
-      if (
-        //最初のページ
-        i === 1 ||
-        // 最後のページ
-        i === totalPages ||
-        // 現在のページの前後範囲 
-        (i >= currentPage - range && i <= currentPage + range)
-      ) {
-        //ページ番号 i を配列に追加します。
-        pageNumbers.push(i);
-        // 配列の最後の要素が null ではないことを確認します。これにより、連続して null を追加するのを防ぎます。
-      } else if (pageNumbers[pageNumbers.length - 1] !== null) {
-        // 表示しない部分に null を挿入します。
-        pageNumbers.push(null);
-      }
+  // 左側に省略記号を出す条件,半分を超えたページから表示
+  const hasLeftEllipsis =
+    totalPages > maxNumLength &&
+    maxNumLength >= 7 &&
+    currentPage > halfMaxNumLength;
+
+  //右の省略記号は最終ページから表示数の半分を引いたページまで表示
+  const hasRightEllipsis =
+    totalPages > maxNumLength &&
+    maxNumLength >= 7 &&
+    currentPage < totalPages - halfMaxNumLength;
+
+  const paginationNumbers = () => {
+    // ページ数がmaxNumLength以下の場合は全て表示する
+    if (totalPages <= maxNumLength) {
+      return range(1, totalPages);
     }
-    return pageNumbers;
+    // < 1 2 3 4 5 … 10 > のように省略記号が右のみの場合
+    if (!hasLeftEllipsis && hasRightEllipsis) {
+      //例: maxNumLength = 7, totalPages = 10 の場合 → [1, 2, 3, 4, 5, 10]
+      return [...range(1, maxNumLength - 2), totalPages];
+    }
+    // < 1 … 6 7 8 9 10 > のように省略記号が左のみの場合
+    if (hasLeftEllipsis && !hasRightEllipsis) {
+      //最初の1と最後のtotalPagesは固定、Math.round(maxNumLength / 2) は maxNumLength を2で割って四捨五入した値です。
+      return [
+        1,
+        ...range(totalPages - Math.round(maxNumLength / 2), totalPages),
+      ];
+    }
+    // < 1 … 5 6 7 … 10 > のように省略記号が両方の場合
+    const startNum = currentPage - (halfMaxNumLength - 2); // 最初のページと省略記号を除いたページ数
+    const endNum = currentPage + (halfMaxNumLength - 2); // 最後のページと省略記号を除いたページ数
+    return [1, ...range(startNum, endNum), totalPages];
   };
 
+  const numbers = paginationNumbers();
+  console.log(numbers, "left:" + hasLeftEllipsis, "right:" + hasRightEllipsis);
   return (
-    <nav>
+    <>
       <ul className={styles.pagination}>
-        <li>
-          <Link
-            href={currentPage > 1 ? `/page/${currentPage - 1}` : "#"}
-            className={`${styles.paginationButton} ${
-              currentPage === 1 ? styles.disabled : ""
-            }`}
-          >
-            前へ
-          </Link>
-        </li>
-
-        {getPageNumbers().map((page, index) =>
-          page === null ? (
-            <span key={index} className={styles.paginationEllipsis}>
-              ...
-            </span>
-          ) : (
-            <li key={index}>
-              <Link
-                href={`/page/${page}`}
-                className={`${styles.paginationPage} ${
-                  page === currentPage ? styles.active : ""
-                }`}
-              >
-                {page}
-              </Link>
-            </li>
-          )
-        )}
-
-        <li>
-          <Link
-            href={currentPage >= 1 ? `/page/${currentPage + 1}` : "#"}
-            className={`${styles.paginationButton} ${
-              currentPage === totalPages ? styles.disabled : ""
-            }`}
-          >
-            次へ
-          </Link>
-        </li>
+        {numbers.map((number) => {
+          return (
+            <Fragment key={number}>
+              {hasRightEllipsis && number === totalPages && <li>...</li>}
+              <li>
+                <Link
+                  href={`/page/${number}`}
+                  className={`${styles.paginationPage} ${
+                    number === currentPage ? styles.active : ""
+                  }`}
+                >
+                  {number}
+                </Link>
+              </li>
+              {hasLeftEllipsis && number === 1 && <li>...</li>}
+            </Fragment>
+          );
+        })}
       </ul>
-    </nav>
+    </>
   );
 };
-// export const Pagination = ({ totalCount }) => {
-//   //1ページに何枚表示するか
-//   const PER_PAGE = BLOG_LIMIT;
-
-//   // 現在のページ番号を取得
-//   const router = useRouter();
-//   const currentPage = parseInt(router.query.pageNum || "1", 10);
-
-//   const range = (start, end) =>
-//     /**
-//      * スプレッド構文で展開し、未定義の要素を埋める。
-//      */
-//     [...Array(end - start + 1)].map((_, i) => start + i);
-//   return (
-//     <ul className={styles.pageList}>
-//       <li>
-//         <Link href={currentPage > 1 ? `/page/${currentPage - 1}` : "#"} className={currentPage === 1 ? styles.disabled : ""}>
-//           前へ
-//         </Link>
-//       </li>
-//       {range(1, Math.ceil(totalCount / PER_PAGE)).map((number) => (
-//         <li
-//           className={currentPage === number ? styles.currentStyle : ""}
-//           key={number}
-//         >
-//           <Link href={`/page/${number}`}>{number}</Link>
-//         </li>
-//       ))}
-//       <li>
-//         <Link href={currentPage >= 1 ? `/page/${currentPage + 1}` : "#"} className={currentPage === (totalCount / PER_PAGE) ? styles.disabled : ""}>次へ</Link>
-//       </li>
-//     </ul>
-//   );
-// };

--- a/src/components/pagination/Pagination.tsx
+++ b/src/components/pagination/Pagination.tsx
@@ -60,7 +60,6 @@ export const Pagination = ({
   };
 
   const numbers = paginationNumbers();
-  console.log(numbers, "left:" + hasLeftEllipsis, "right:" + hasRightEllipsis);
   return (
     <>
       <ul className={styles.pagination}>

--- a/src/components/pagination/Pagination.tsx
+++ b/src/components/pagination/Pagination.tsx
@@ -8,18 +8,12 @@ import styles from "./Pagination.module.scss";
 type PaginationProps = {
   totalCount: number;
   limit: number;
+  currentPage: number;
 }
 
-export const Pagination = ({ totalCount, limit }: PaginationProps) => {
+export const Pagination = ({ totalCount, limit, currentPage }: PaginationProps) => {
   //全部で何ページのページネーションにするかの計算
   const totalPages = Math.ceil(totalCount / limit);
-  // 現在のページ番号を取得
-  const router = useRouter();
-  /**
-   * ||の代わりに??を使うことで、undefinedまたはnullの場合のみデフォルト値を適用できます。
-   * ??は、0や空文字列（""）を「有効な値」として扱うため、意図しないデフォルト値の適用を防ぎます。
-   */
-  const currentPage = Number(router.query.pageNum ?? 1);
 
   const getPageNumbers = () => {
     const pageNumbers = [];

--- a/src/constants/blogLimit.ts
+++ b/src/constants/blogLimit.ts
@@ -1,0 +1,1 @@
+export const BLOG_LIMIT = 6;

--- a/src/constants/blogLimit.ts
+++ b/src/constants/blogLimit.ts
@@ -1,1 +1,1 @@
-export const BLOG_LIMIT = 6;
+export const BLOG_LIMIT = 2;

--- a/src/constants/blogLimit.ts
+++ b/src/constants/blogLimit.ts
@@ -1,1 +1,1 @@
-export const BLOG_LIMIT = 2;
+export const BLOG_LIMIT = 1;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -32,10 +32,14 @@ const Home: NextPage<HomeProps> = ({ blog }) => {
 };
 
 export const getStaticProps: GetStaticProps<HomeProps> = async () => {
+  const pageNum = 1;
+  const offset = (pageNum - 1) * 6;
   const data = await client.getList<BlogList>({
     endpoint: "blog",
     queries: {
       fields: "id,title,thumbnail,alt,category",
+      limit: 6,
+      offset,
     },
   });
   return {

--- a/src/pages/page/[pageNum].tsx
+++ b/src/pages/page/[pageNum].tsx
@@ -11,11 +11,13 @@ import { BLOG_LIMIT } from "@/constants/blogLimit";
 
 type HomeProps = {
   blog: MicroCMSListResponse<BlogList>;
+  limit: number;
   //MicroCMSListResponsをtotalCountでも使用したかったが、getStaticPropsでエラーが出た
   totalCount: number;
 };
 
-const Home: NextPage<HomeProps> = ({ blog, totalCount }) => {
+
+const Home: NextPage<HomeProps> = ({ blog, totalCount, limit }) => {
   return (
     <div>
       <h1>ブログ一覧</h1>
@@ -28,7 +30,7 @@ const Home: NextPage<HomeProps> = ({ blog, totalCount }) => {
           </li>
         ))}
       </ul>
-      <Pagination totalCount={totalCount} />
+      <Pagination totalCount={totalCount} limit={limit}/>
     </div>
   );
 };
@@ -53,6 +55,7 @@ export const getStaticPaths: GetStaticPaths<Params> = async () => {
 export const getStaticProps: GetStaticProps<HomeProps> = async ({ params }) => {
   // ルートのパラメータpageNumを取得します。例えば、URLが/page/1の場合、pageNumは1になります。offsetで使用している paramsが無い時はどんな時？
   const pageNum = Number(params?.pageNum);
+
   //offsetのデフォルトは０なので、pageNumから−１をしている
   const offset = (pageNum - 1) * BLOG_LIMIT;
   const data = await client.getList<BlogList>({
@@ -67,6 +70,7 @@ export const getStaticProps: GetStaticProps<HomeProps> = async ({ params }) => {
     props: {
       blog: data,
       totalCount: data.totalCount,
+      limit: BLOG_LIMIT,
     },
   };
 };

--- a/src/pages/page/[pageNum].tsx
+++ b/src/pages/page/[pageNum].tsx
@@ -5,14 +5,17 @@ import { MicroCMSListResponse } from "microcms-js-sdk";
 import styles from "@/styles/Home.module.scss";
 import Link from "next/link";
 import { BlogCard } from "@/components/blogcard/BlogCard";
+import { Pagination } from "@/components/pagination/Pagination";
 import { ParsedUrlQuery } from "querystring";
 import { BLOG_LIMIT } from "@/constants/blogLimit";
 
 type HomeProps = {
   blog: MicroCMSListResponse<BlogList>;
+  //MicroCMSListResponsをtotalCountでも使用したかったが、getStaticPropsでエラーが出た
+  totalCount: number;
 };
 
-const Home: NextPage<HomeProps> = ({ blog }) => {
+const Home: NextPage<HomeProps> = ({ blog, totalCount }) => {
   return (
     <div>
       <h1>ブログ一覧</h1>
@@ -25,6 +28,7 @@ const Home: NextPage<HomeProps> = ({ blog }) => {
           </li>
         ))}
       </ul>
+      <Pagination totalCount={totalCount} />
     </div>
   );
 };
@@ -38,7 +42,7 @@ export const getStaticPaths: GetStaticPaths<Params> = async () => {
    * 現在は空の配列が指定されており、事前生成されるページはありません。
    * fallback: 'blocking' キャッシュがまだ作られていないときはSSRを行う
    */
-  
+
   return { paths: [], fallback: "blocking" };
 };
 
@@ -62,6 +66,7 @@ export const getStaticProps: GetStaticProps<HomeProps> = async ({ params }) => {
   return {
     props: {
       blog: data,
+      totalCount: data.totalCount,
     },
   };
 };

--- a/src/pages/page/[pageNum].tsx
+++ b/src/pages/page/[pageNum].tsx
@@ -1,0 +1,69 @@
+import { GetStaticPaths, GetStaticProps, NextPage } from "next";
+import { client } from "@/libs/client";
+import { BlogList } from "@/types/blog";
+import { MicroCMSListResponse } from "microcms-js-sdk";
+import styles from "@/styles/Home.module.scss";
+import Link from "next/link";
+import { BlogCard } from "@/components/blogcard/BlogCard";
+import { ParsedUrlQuery } from "querystring";
+import { BLOG_LIMIT } from "@/constants/blogLimit";
+
+type HomeProps = {
+  blog: MicroCMSListResponse<BlogList>;
+};
+
+const Home: NextPage<HomeProps> = ({ blog }) => {
+  return (
+    <div>
+      <h1>ブログ一覧</h1>
+      <ul className={styles.blogLists}>
+        {blog.contents.map((blog) => (
+          <li className={styles.blogList} key={blog.id}>
+            <Link href={`/blog/${blog.id}`}>
+              <BlogCard blog={blog} />
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+type Params = {
+  pageNum: string;
+} & ParsedUrlQuery;
+
+export const getStaticPaths: GetStaticPaths<Params> = async () => {
+  /**
+   * ビルド時に事前に生成するページのパスを配列で指定します。
+   * 現在は空の配列が指定されており、事前生成されるページはありません。
+   * fallback: 'blocking' キャッシュがまだ作られていないときはSSRを行う
+   */
+  
+  return { paths: [], fallback: "blocking" };
+};
+
+/**
+ * paramsからページ番号を取得します。
+ * ページ番号を基にデータの取得開始位置(offset)を計算します。
+ */
+export const getStaticProps: GetStaticProps<HomeProps> = async ({ params }) => {
+  // ルートのパラメータpageNumを取得します。例えば、URLが/page/1の場合、pageNumは1になります。offsetで使用している paramsが無い時はどんな時？
+  const pageNum = Number(params?.pageNum);
+  //offsetのデフォルトは０なので、pageNumから−１をしている
+  const offset = (pageNum - 1) * BLOG_LIMIT;
+  const data = await client.getList<BlogList>({
+    endpoint: "blog",
+    queries: {
+      fields: "id,title,thumbnail,alt,category",
+      limit: BLOG_LIMIT,
+      offset,
+    },
+  });
+  return {
+    props: {
+      blog: data,
+    },
+  };
+};
+
+export default Home;

--- a/src/pages/page/[pageNum].tsx
+++ b/src/pages/page/[pageNum].tsx
@@ -10,14 +10,15 @@ import { ParsedUrlQuery } from "querystring";
 import { BLOG_LIMIT } from "@/constants/blogLimit";
 
 type HomeProps = {
+  //MicroCMSListResponsをtotalCountでも使用したかったが、getStaticPropsでエラーが出た
   blog: MicroCMSListResponse<BlogList>;
   limit: number;
-  //MicroCMSListResponsをtotalCountでも使用したかったが、getStaticPropsでエラーが出た
   totalCount: number;
+  currentPage: number;
 };
 
 
-const Home: NextPage<HomeProps> = ({ blog, totalCount, limit }) => {
+const Home: NextPage<HomeProps> = ({ blog, totalCount, limit, currentPage }) => {
   return (
     <div>
       <h1>ブログ一覧</h1>
@@ -30,7 +31,8 @@ const Home: NextPage<HomeProps> = ({ blog, totalCount, limit }) => {
           </li>
         ))}
       </ul>
-      <Pagination totalCount={totalCount} limit={limit}/>
+      {/* Paginationコンポーネントの中で型定義がされてないと親コンポーネントでエラーが出る？ */}
+      <Pagination totalCount={totalCount} limit={limit} currentPage={currentPage}/>
     </div>
   );
 };
@@ -64,7 +66,7 @@ const paths = Array.from({ length: totalPages }, (_, i) => ({
  */
 export const getStaticProps: GetStaticProps<HomeProps> = async ({ params }) => {
   // ルートのパラメータpageNumを取得します。例えば、URLが/page/1の場合、pageNumは1になります。offsetで使用している paramsが無い時はどんな時？
-  const pageNum = Number(params?.pageNum);
+  const pageNum = Number(params?.pageNum ?? 1);
    // ページ番号が無効（数字でない、1未満）の場合は404
    if (isNaN(pageNum) || pageNum < 1) {
     return { notFound: true };
@@ -97,6 +99,7 @@ export const getStaticProps: GetStaticProps<HomeProps> = async ({ params }) => {
       blog: data,
       totalCount: data.totalCount,
       limit: BLOG_LIMIT,
+      currentPage: pageNum,
     },
   };
 };

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -105,3 +105,8 @@ a {
     color-scheme: dark;
   }
 } */
+
+a {
+  color: inherit;
+  text-decoration: none;
+}

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -1,4 +1,5 @@
-import { MicroCMSListContent, MicroCMSImage } from "microcms-js-sdk";
+import { MicroCMSListContent, MicroCMSImage, MicroCMSListResponse } from "microcms-js-sdk";
+
 
 export type Category = {
   name: string;
@@ -13,4 +14,4 @@ export type Blog = {
   body: string;
   thumbnail: MicroCMSImage;
   category: Category & MicroCMSListContent; //MicroCMSListContentの型定義を&で追加している
-};
+} & MicroCMSListResponse<BlogList>;

--- a/src/utils/range.ts
+++ b/src/utils/range.ts
@@ -1,0 +1,13 @@
+/**
+   * range関数 - startからendまでの数値の配列を返す
+   * @param start
+   * @param end
+   * @returns
+   * range(1, 5) // [1, 2, 3, 4, 5]
+   */
+export const range = (start: number, end: number) => {
+  if (start > end) {
+    return [];
+  }
+  return [...Array(end - start + 1)].map((_, i) => start + i);
+};


### PR DESCRIPTION
<!-- この内容を全てPRに貼り付ける -->

## 目的

<!-- タスクの目的を出来るだけわかりやすく詳細に書く -->

現在はブログ記事を全件（正しくはmicroCMSのデフォルトlimitの100件）を取得していると思います。

ブログ記事が増えてきたときには全件取得はデータ量が多くて重たくなるのでページネーションすることになります。

ページネーションするにはどういう実装にしたらいいかを検討してみるのも良いかもです！

## 実施内容

<!-- 具体的に何をするのかを出来るだけ分かりやすく詳細に書く -->

- [x]  ブログ一覧ページにページネーション機能を実装
- [x]  ページが多くなった時のための対策（…などを入れる）
- [x]  ページネーションの範囲外へのリンクをできないように（404を返すなど）
- [x]  現在のページがわかるように見た目を変更

## Screenshots

<!-- スクリーンショットを添付する -->

[]()

[]()

## テスト

<!-- 動作確認方法やテスト手順を出来るだけ詳細に書く -->

## 確認事項

<!-- 問題点は可能な限り対応して難しい場合は補足に記載する -->

- [ ]  動作確認をしたか？
- [ ]  新たにエラーは発生していないか？
- [ ]  merge後に新たなTaskやIssueは発生するか？（発生する場合はTaskを作成したか？）

## 補足

<!-- 補足すべきことがあれば書く -->

# offset

コンテンツを取得開始する位置を、指定した値だけ後ろにずらします。

デフォルト値は`0`です。